### PR TITLE
Replaced Python app with IBM version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,107 @@
+# Local environment
+.DS_Store
+Thumbs.db
+
+# pipenv virtual environment
+.venv
+
+# Test reports
+unittests.xml
+
+# database files
+db/*
+!db/.keep
+
+# SonarQube Reports
+.scannerwork/
+.sonarlint/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
+*.py[cod]
+*$py.class
 
-# Environments
-.env
-.venv
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
 env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
 venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2017 Grey Li
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,45 +1,27 @@
-# Flask Examples
+# DevSecOps HTTP Application
 
-Example applications for Flask beginners.
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Python 3.6](https://img.shields.io/badge/Python-3.6-green.svg)](https://shields.io/)
 
-## Installation
+This repository contains the practice code for the **Code Practices** lab in the Coursera.org course [**IBM-CD0267EN-SkillsNetwork Application Security and Monitoring**](https://www.coursera.org/learn/application-security-and-monitoring)
 
-First, you need to clone this repository:
+## Contents
 
-```bash
-$ git clone git@github.com:greyli/flask-examples.git
-```
+This lab contains a Python Flask backend with a React frontend. It demonstrates the use of **Flask-CORS** to remediate Cross Origin Resource Sharing (CORS) vulnerabilities and **Flask-Talisman** for creating secure HTTP headers.
 
-Or:
+## Authors
 
-```bash
-$ git clone https://github.com/helloflask/flask-examples.git
-```
-
-Now, we will need to create a virtual environment and install all the dependencies:
-
-```bash
-$ python3 -m venv venv  # on Windows, use "python -m venv venv" instead
-$ . venv/bin/activate  # on Windows, use "venv\Scripts\activate" instead
-$ pip install -r requirements.txt
-```
-
-## How to Run a Specific Example Application?
-
-**Before run a specific example application, make sure you have activated the virtual environment.**
-
-You can run HTTP application like this:
-
-```bash
-$ flask run
-```
-
-The applications will always running on http://localhost:5000.
-
-## Contributions
-
-Cloned from `https://github.com/helloflask/flask-examples`, thanks to Grey Li for creating the template code.
+[Richard Ye](https://www.linkedin.com/in/richard-ye)  
+[John J. Rofrano](https://www.coursera.org/instructor/johnrofrano) Senior Technical Staff Member, DevOps Champion, @ IBM Research  
 
 ## License
 
-This project is licensed under the MIT License (see the `LICENSE` file for details).
+Copyright (c) IBM Corporation. All rights reserved.
+
+Licensed under the Apache License. See [LICENSE](LICENSE)
+
+This repo is part of the Coursera.org course [IBM-CD0267EN-SkillsNetwork Application Security and Monitoring](https://www.coursera.org/learn/application-security-and-monitoring/)
+
+---
+
+## <h3 align="center"> © IBM Corporation 2022. All rights reserved. <h3/>

--- a/app.py
+++ b/app.py
@@ -1,31 +1,28 @@
-import os
-import requests
-from flask import Flask, request, abort, jsonify
+from flask import Flask, jsonify
 from flask_cors import CORS
 from flask_talisman import Talisman
+from post_factory import PostFactory
 
 app = Flask(__name__)
-app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 0
 
 csp = {
     'default-src': '\'self\''
 }
 # talisman = Talisman(app, content_security_policy=csp)
-# CORS(app, resources={"/*": {"origins": "http://localhost:3000"}})
 
-@app.route('/')
-@app.route('/hello')
-def hello():
-    response = '<h1>Hello, human!</h1>'
-    return response
+# Enable Cross Origin Resource Sourcing (CORS) policies
+CORS(app, resources={"/*": {"origins": "http://localhost:3000"}})
 
-# 404
-@app.route('/404')
-def not_found():
-    abort(404)
 
-@app.route('/serve')
+@app.route("/")
+def index():
+    """Root URL response"""
+    app.logger.info("Request for Root URL")
+    return (jsonify(name="Data Retrieval Service", version="1.0"), 200)
+
+
+@app.route('/posts')
 def serve_data():
-    raw = requests.get('https://jsonplaceholder.typicode.com/posts/1/comments')
-    data = raw.json()
+    """Returns forum post data"""
+    data = PostFactory.generate(5)
     return jsonify(data)

--- a/app.py
+++ b/app.py
@@ -22,7 +22,7 @@ def index():
 
 
 @app.route("/posts", methods=["GET"])
-def serve_data():
+def get_data():
     """Returns forum post data"""
     data = PostFactory.generate(5)
     return jsonify(data)

--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ def index():
     return (jsonify(name="Data Retrieval Service", version="1.0"), 200)
 
 
-@app.route('/posts')
+@app.route("/posts", methods=["GET"])
 def serve_data():
     """Returns forum post data"""
     data = PostFactory.generate(5)

--- a/frontend/src/components/data.jsx
+++ b/frontend/src/components/data.jsx
@@ -7,7 +7,7 @@ const Data = () => {
   try {
     useEffect(() => {
       const fetchData = async () => {
-        const rawData = await fetch("http://127.0.0.1:5000/serve")
+        const rawData = await fetch("http://127.0.0.1:5000/posts")
           .then((data) => data.json())
           .then((response) => {
             setData(response);

--- a/post_factory.py
+++ b/post_factory.py
@@ -1,0 +1,41 @@
+"""
+PostFactory - generates fake forum posts
+
+Example usage:
+    PostFactory.generate(5)
+
+Returns:
+    A list of 5 fake posts
+"""
+
+from faker import Faker
+
+class PostFactory():
+    """Creates fake posts"""
+    fake = Faker()
+    counter = 0
+
+    def __init__(self):
+        """Constructor"""
+        PostFactory.counter += 1
+        self.id = PostFactory.counter
+        self.name = self.fake.name()
+        self.email = self.fake.email()
+        self.body = self.fake.text()
+
+    def serialize(self) -> dict:
+        """Returns the instance as a dictionary"""
+        return {
+            "id": self.id,
+            "postID": 1,
+            "name": self.name,
+            "email": self.email,
+            "body": self.body
+        }
+
+    @staticmethod
+    def generate(max: int = 1) -> list:
+        results = []
+        for _ in range(max):
+            results.append(PostFactory().serialize())
+        return results

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask
-Faker
-Flask-Cors
-flask-talisman
+Flask==2.2.2
+Faker==14.2.0
+Flask-Cors==3.0.10
+flask-talisman==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,4 @@
-certifi==2022.6.15
-charset-normalizer==2.0.0
-click==7.1.2
-Flask==1.1.4
-Flask-Cors==3.0.10
-flask-talisman==1.0.0
-flask-wtf<=0.15
-httpx >=0.20
-idna==3.3
-importlib-metadata==4.8.3
-itsdangerous==1.1.0
-Jinja2==2.11.3
-MarkupSafe<2.0.0
-requests==2.27.1
-six==1.16.0
-SQLAlchemy<1.4.0
-urllib3==1.26.11
-Werkzeug==1.0.1
-zipp==3.6.0
+Flask
+Faker
+Flask-Cors
+flask-talisman


### PR DESCRIPTION
Made the following changes:
- Created a new Python app with a `/posts` endpoint
- Removed external web site call in favor of using generated test data
- Updated requirements to work in IBM SkillsNetwork lab environment
- Changed the license to Apache 2.0